### PR TITLE
Add support for Thinkpad Edge 430

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -50,6 +50,7 @@ my $aslBases = {
   'ThinkPad Edge S430' => '\_SB.PCI0.LPCB.EC0.HKEY',
   'ThinkPad Edge E335' => '\_SB.PCI0.LPC0.EC0.HKEY',
   'ThinkPad T430u'     => '\_SB.PCI0.LPCB.EC.HKEY',
+  'ThinkPad Edge E430' => '\_SB.PCI0.LPCB.EC0.HKEY',
 };
 
 sub getMethod($$$);


### PR DESCRIPTION
This model does not work with the `default` aslBase.
