### PR TITLE
Add ThinkPad Edge E530 Support

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -51,6 +51,7 @@ my $aslBases = {
   'ThinkPad Edge E335' => '\_SB.PCI0.LPC0.EC0.HKEY',
   'ThinkPad T430u'     => '\_SB.PCI0.LPCB.EC.HKEY',
   'ThinkPad Edge E430' => '\_SB.PCI0.LPCB.EC0.HKEY',
+  'ThinkPad Edge E530' => '\_SB.PCI0.LPCB.EC0.HKEY',
 };
 
 sub getMethod($$$);


### PR DESCRIPTION
This adds support for setting battery thresholds to the Lenovo ThinkPad Edge E530. #20
