### PR TITLE
getASLBase(): match $dmiVersion with regex

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -46,7 +46,7 @@ my $aslBases = {
   'ThinkPad L[45][34]0'                   => '\_SB.PCI0.LPCB.H_EC.HKEY',
   'ThinkPad (Edge|).*S[45][34][01]'       => '\_SB.PCI0.LPCB.EC0.HKEY',
   'ThinkPad T430u'                        => '\_SB.PCI0.LPCB.EC.HKEY',
-  'ThinkPad X1[23[01]e'                   => '\_SB.PCI0.LPCB.EC.HKEY',
+  'ThinkPad X1[23][01]e'                   => '\_SB.PCI0.LPCB.EC.HKEY',
 };
 
 sub getMethod($$$);


### PR DESCRIPTION
If you reorder and group the currently known models by families and
hardware generations a pattern appears:

 'ThinkPad E420s'     => '_SB.PCI0.LPCB.EC0.HKEY',

 'ThinkPad Edge E335' => '_SB.PCI0.LPC0.EC0.HKEY',

 'ThinkPad Edge E430' => '_SB.PCI0.LPCB.EC0.HKEY',
 'ThinkPad Edge E431' => '_SB.PCI0.LPCB.EC0.HKEY',
 'ThinkPad Edge E530' => '_SB.PCI0.LPCB.EC0.HKEY',

 'ThinkPad L430'      => '_SB.PCI0.LPCB.H_EC.HKEY',
 'ThinkPad L530'      => '_SB.PCI0.LPCB.H_EC.HKEY',

 'ThinkPad S420'      => '_SB.PCI0.LPCB.EC0.HKEY',

 'ThinkPad S430'      => '_SB.PCI0.LPCB.EC0.HKEY',
 'ThinkPad Edge S430' => '_SB.PCI0.LPCB.EC0.HKEY',
 'ThinkPad S431'      => '_SB.PCI0.LPCB.EC0.HKEY',
 'ThinkPad S3-S431'   => '_SB.PCI0.LPCB.EC0.HKEY',

 'ThinkPad T430u'     => '_SB.PCI0.LPCB.EC.HKEY',

 'ThinkPad X121e'     => '_SB.PCI0.LPCB.EC.HKEY',

With some guesswork about the upcoming *4? generation one can
combine the pattern into just a few regular expressions.

I think this may reduce the number of issues to add single models
significantly.
