### PR TITLE
add support for edge e330, resolves issue #33

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -51,6 +51,7 @@ my $aslBases = {
   'ThinkPad S3-S431'     => '\_SB.PCI0.LPCB.EC0.HKEY',
   'ThinkPad S431'        => '\_SB.PCI0.LPCB.EC0.HKEY',
   'ThinkPad Edge S430'   => '\_SB.PCI0.LPCB.EC0.HKEY',
+  'ThinkPad Edge E330'   => '\_SB.PCI0.LPCB.H_EC.HKEY',
   'ThinkPad Edge E335'   => '\_SB.PCI0.LPC0.EC0.HKEY',
   'ThinkPad T430u'       => '\_SB.PCI0.LPCB.EC.HKEY',
   'ThinkPad Edge E430'   => '\_SB.PCI0.LPCB.EC0.HKEY',


### PR DESCRIPTION
Add support for Thinkpad Edge E330 models, as discussed in teleshoes/tpacpi-bat/#33
