### PR TITLE
systemd: add RemainAfterExit and ExecStop

### DIFF
--- a/tpacpi.service
+++ b/tpacpi.service
@@ -3,8 +3,11 @@ Description=sets battery thresholds
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/tpacpi-bat -s ST 0 40
 ExecStart=/usr/bin/tpacpi-bat -s SP 0 80
+ExecStop=/usr/bin/tpacpi-bat -s ST 0 0
+ExecStop=/usr/bin/tpacpi-bat -s SP 0 100
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
With this .service file, the battery charge limits can be reset to the default if the service is stopped.
