### PR TITLE
allow the systemd service to also be stopped

### DIFF
--- a/tpacpi.service
+++ b/tpacpi.service
@@ -3,8 +3,11 @@ Description=sets battery thresholds
 
 [Service]
 Type=oneshot
+RemainAfterExit=yes
 ExecStart=/usr/bin/tpacpi-bat -s ST 0 40
 ExecStart=/usr/bin/tpacpi-bat -s SP 0 80
+ExecStop=/usr/bin/tpacpi-bat -s ST 0 0
+ExecStop=/usr/bin/tpacpi-bat -s SP 0 0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This makes it easier to disable the special charging logic when you actually do want the battery to be fully charged.
