### PR TITLE
sanitize the path before calling an external program

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -387,6 +387,7 @@ sub acpiCall($){
   my $call = shift;
 
   if(not -e $acpiCallDev){
+    $ENV{'PATH'} = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
     system "modprobe acpi_call";
   }
   if(not -e $acpiCallDev){


### PR DESCRIPTION
This is useful for calling tpacpi-bat from suid/sgid programs for example not to require users to use sudo command each time they want to change battery charge thresholds.
