### PR TITLE
Change url for fetching acpi_call.

### DIFF
--- a/install.pl
+++ b/install.pl
@@ -3,7 +3,7 @@ use strict;
 use warnings;
 
 my $prefix = '/usr';
-my $acpiCallGitRepo = 'git://github.com/teleshoes/acpi_call.git';
+my $acpiCallGitRepo = 'https://github.com/mkottman/acpi_call.git';
 
 sub runOrDie(@){
   print "@_\n";


### PR DESCRIPTION
        - previously used address employed ssh url leaded to connection
          timeout persumably because it required relevant permissions.
        - current url is https which makes fetching project in
          install.pl script possible for the public.