### PR TITLE
remove battery limit settings when systemd service stopped

### DIFF
--- a/examples/systemd_dynamic_threshold/tpacpi.service
+++ b/examples/systemd_dynamic_threshold/tpacpi.service
@@ -7,6 +7,8 @@ RemainAfterExit=yes
 EnvironmentFile=-/etc/conf.d/tpacpi
 ExecStart=/usr/bin/tpacpi-bat -s ST $BATTERY $START_THRESHOLD
 ExecStart=/usr/bin/tpacpi-bat -s SP $BATTERY $STOP_THRESHOLD
+ExecStop=/usr/bin/tpacpi-bat -s ST $BATTERY 0
+ExecStop=/usr/bin/tpacpi-bat -s SP $BATTERY 0
 
 [Install]
 WantedBy=multi-user.target

--- a/examples/systemd_fixed_threshold/tpacpi.service
+++ b/examples/systemd_fixed_threshold/tpacpi.service
@@ -6,6 +6,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/tpacpi-bat -s ST 0 40
 ExecStart=/usr/bin/tpacpi-bat -s SP 0 80
+ExecStop=/usr/bin/tpacpi-bat -s ST $BATTERY 0
+ExecStop=/usr/bin/tpacpi-bat -s SP $BATTERY 0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The sample doesn't turn off the limits tpacpi-bat sets when it's stopped. This PR fixes that.

Arch bug: https://bugs.archlinux.org/task/55063