### PR TITLE
examples: do not use conf variables for fixed-threshold example

### DIFF
--- a/examples/systemd_fixed_threshold/tpacpi.service
+++ b/examples/systemd_fixed_threshold/tpacpi.service
@@ -6,8 +6,8 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/tpacpi-bat -s ST 0 40
 ExecStart=/usr/bin/tpacpi-bat -s SP 0 80
-ExecStop=/usr/bin/tpacpi-bat -s ST $BATTERY 0
-ExecStop=/usr/bin/tpacpi-bat -s SP $BATTERY 0
+ExecStop=/usr/bin/tpacpi-bat -s ST 0 0
+ExecStop=/usr/bin/tpacpi-bat -s SP 0 0
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Conf variables are not expected to be available to the fixed-threshold
service.

Bug was introduced in #82.
