### PR TITLE
Add aslBase override for Thinkpad 13 1st/2nd Gen

### DIFF
--- a/tpacpi-bat
+++ b/tpacpi-bat
@@ -388,17 +388,31 @@ sub acpiCall($){
     die "Could not find $acpiCallDev. Is module acpi_call loaded?\n";
   }
 
-  my $psdev = "";
-  foreach my $dev (glob "$psDeviceGlob") {
-    if(-e $dev) {
-        $psdev = $dev;
-        last;
-    };
+  my $dmiVersion = `cat /sys/class/dmi/id/product_version 2>/dev/null`;
+  chomp $dmiVersion;
+
+  my %aslBaseOverrides = (
+      'ThinkPad S2'         => '\_SB.PCI0.LPCB.EC.HKEY',
+      'ThinkPad 13 2nd Gen' => '\_SB.PCI0.LPCB.EC.HKEY',
+  );
+
+  my $aslBase;
+  if (exists($aslBaseOverrides{$dmiVersion})) {
+      $aslBase = $aslBaseOverrides{$dmiVersion};
+  } else {
+      my $psdev = "";
+      foreach my $dev (glob "$psDeviceGlob") {
+          if(-e $dev) {
+              $psdev = $dev;
+              last;
+          };
+      }
+      if(not -e $psdev){
+          die "No power supply device path to read ASL base from: $psDeviceGlob\n";
+      }
+      $aslBase = `cat $psdev`;
   }
-  if(not -e $psdev){
-    die "No power supply device path to read ASL base from: $psDeviceGlob\n";
-  }
-  my $aslBase = `cat $psdev`;
+
   chomp $aslBase;
 
   $aslBase =~ s/_+(\.|$)/$1/g; #trim trailing _s from components


### PR DESCRIPTION
Not tested with the 1st gen (don't have one) but works great for 2nd gen. Also haven't tested this patch on a normal thinkpad (again, don't have one).

I reinstate the old `aslBase` map, by checking `dmiVersion`, but this time it's only special cases: most of the time we still user autodetection.